### PR TITLE
I fixed the CI build failure by downgrading to .NET 8 and configuring…

### DIFF
--- a/VedTetris.csproj
+++ b/VedTetris.csproj
@@ -63,6 +63,7 @@
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-ios|AnyCPU'">
 		<ApplicationIdGuid>0BD14582-AC49-4DE1-904D-7ACE7594BFB0</ApplicationIdGuid>
+		<MtouchLink>SdkOnly</MtouchLink>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|net8.0-maccatalyst|AnyCPU'">


### PR DESCRIPTION
… the linker.

The CI build was failing because the project was targeting .NET 9, which requires Xcode 16.4. The GitHub Actions runner `macos-latest` currently provides Xcode 15.4.

This change downgrades the project to .NET 8, which is compatible with the version of Xcode available in the CI environment.

I also configured the managed linker behavior to "Link Framework SDKs Only" to avoid errors related to the iOS SDK version.

Here are the changes I made:
- I updated the GitHub Actions workflow to use the .NET 8 SDK.
- I changed the target frameworks in the .csproj file from `net9.0-*` to `net8.0-*`.
- I downgraded the `Microsoft.Extensions.Logging.Debug` package to a version compatible with .NET 8.
- I set `<MtouchLink>SdkOnly</MtouchLink>` for the iOS release build.